### PR TITLE
Updates .NET version to 8 (Azure does not support pre-8 versions anymore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ BenchmarkDotNet.Artifacts/
 project.lock.json
 project.fragment.lock.json
 artifacts/
+**/out/
 
 # ASP.NET Scaffolding
 ScaffoldingReadMe.txt

--- a/Chapter03/01-aspnetapp/Dockerfile
+++ b/Chapter03/01-aspnetapp/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -11,7 +11,7 @@ COPY aspnetapp/. .
 RUN dotnet publish -c Release -o /app --use-current-runtime --self-contained false --no-restore
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS run
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS run
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["dotnet", "aspnetapp.dll"]

--- a/Chapter03/01-aspnetapp/aspnetapp/aspnetapp.csproj
+++ b/Chapter03/01-aspnetapp/aspnetapp/aspnetapp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>57393389627611478466</UserSecretsId>


### PR DESCRIPTION
The .NET application version is updated from 7 to 8 (LTS).
Azure does not support version lower than 8 anymore.
Also .gitignore is updated to ignore **/out generated folders.

**Also, the .NET applications then run on port 8080** - the commands in the exercises to run a docker image must be updated along the way with this.