### PR TITLE
Updates exercise to .NET 8

### DIFF
--- a/Chapter03/02-azure-container-apps/demoapi/Dockerfile
+++ b/Chapter03/02-azure-container-apps/demoapi/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -11,7 +11,7 @@ COPY . .
 RUN dotnet publish -c Release -o /app --use-current-runtime --self-contained false --no-restore
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS run
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS run
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["dotnet", "demoapi.dll"]

--- a/Chapter03/02-azure-container-apps/demoapi/demoapi.csproj
+++ b/Chapter03/02-azure-container-apps/demoapi/demoapi.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/Chapter03/02-azure-container-apps/demoapp/Dockerfile
+++ b/Chapter03/02-azure-container-apps/demoapp/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -11,7 +11,7 @@ COPY . .
 RUN dotnet publish -c Release -o /app --use-current-runtime --self-contained false --no-restore
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS run
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS run
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["dotnet", "demoapp.dll"]

--- a/Chapter03/02-azure-container-apps/demoapp/demoapp.csproj
+++ b/Chapter03/02-azure-container-apps/demoapp/demoapp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/Chapter03/02-azure-container-apps/docker-compose.yml
+++ b/Chapter03/02-azure-container-apps/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ./demoapi
       dockerfile: Dockerfile
     ports:
-      - "5101:80"
+      - "5101:8080"
 
   demo-app:
     image: demo-app
@@ -14,7 +14,7 @@ services:
       context: ./demoapp
       dockerfile: Dockerfile
     ports:
-      - "5102:80"
+      - "5102:8080"
     depends_on:
       - demo-api
     environment:


### PR DESCRIPTION
.NET with version < 8 is not supported on Azure anymore.
Updates also the docker-componse port since the .NET image for version 8 uses 8080 by default.