### PR TITLE
Update .NET version for Azure exercise (.NET 6 is not supported anymore)

### DIFF
--- a/Chapter02/02-appsettings-logging/appsettings-logging.csproj
+++ b/Chapter02/02-appsettings-logging/appsettings-logging.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>_02_appsettings_logging</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="7.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updates .NET version to 8 because prior versions of .NET are not supported on Azure anymore.