### PR TITLE
Updates chapter 8 to .NET 8 because prior versions are not supported in Azure anymore

### DIFF
--- a/Chapter08/02-system-assigned/02-system-assigned.csproj
+++ b/Chapter08/02-system-assigned/02-system-assigned.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>_02_system_assigned</RootNamespace>

--- a/Chapter08/03-app-config-labels/03-app-configuration-labels.csproj
+++ b/Chapter08/03-app-config-labels/03-app-configuration-labels.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>_03_app_configuration_labels</RootNamespace>

--- a/Chapter08/04-feature-flags/04-feature-flags.csproj
+++ b/Chapter08/04-feature-flags/04-feature-flags.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>_04_feature_flags</RootNamespace>


### PR DESCRIPTION
The exercises worked for me when updating to .NET 8.

However, the code uses deprecated objects/calls. I guess one might want to have a closer look at the code to future proof it better.